### PR TITLE
Set up GitHub Actions basic CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build, Test and Distribute
+name: Build/Test
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Build
         run: "./gradlew assembleDebug"
       - name: Check
-        run: "./gradlew testDebug lintDebug"
+        run: "./gradlew testDebug jacocoTestReport lintDebug"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Build, Test and Distribute
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Build
+        run: "./gradlew assembleDebug"
+      - name: Check
+        run: "./gradlew testDebug lintDebug"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # github-android-app
+
+[![Build/Test](https://github.com/vgaidarji/github-android-app/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/vgaidarji/github-android-app/actions/workflows/main.yml)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
+    // `id` but not `alias` due to https://github.com/gradle/gradle/issues/20084#issuecomment-1060822638
+    id(libs.plugins.androidApplication.get().pluginId)
+    id(libs.plugins.jetbrainsKotlinAndroid.get().pluginId)
+    id(libs.plugins.jacocoReports.get().pluginId)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.jetbrainsKotlinAndroid) apply false
+    // `id` but not `alias` due to https://github.com/gradle/gradle/issues/20084#issuecomment-1060822638
+    id(libs.plugins.androidApplication.get().pluginId) apply false
+    id(libs.plugins.jetbrainsKotlinAndroid.get().pluginId) apply false
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.android.tools.build.gradle)
+    implementation(libs.jetbrains.kotlin.gradle.plugin)
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/jacoco-reports.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-reports.gradle.kts
@@ -1,0 +1,51 @@
+// https://medium.com/@kurtlemond/migrating-jacoco-reports-gradle-tasks-to-kotlin-dsl-7b566d89ea92
+
+plugins {
+    id("jacoco") apply false
+}
+
+dependencies {
+    "implementation"("org.jacoco:org.jacoco.core:0.8.12")
+}
+
+val excludedFiles = mutableSetOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/*\$ViewInjector*.*",
+    "**/*\$ViewBinder*.*",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Factory*",
+    "**/*_MembersInjector*",
+    "**/*Module*",
+    "**/*Component*",
+    "**/*Test*.*",
+    "**/*Activity*.*",
+    "**android**"
+)
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn("testDebugUnitTest")
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports for Debug build"
+
+    val javaDirectories = fileTree(
+        "${buildDir}/intermediates/classes/debug"
+    ) { exclude(excludedFiles) }
+    val kotlinDirectories = fileTree(
+        "${buildDir}/tmp/kotlin-classes/debug"
+    ) { exclude(excludedFiles) }
+
+    val coverageSrcDirectories = listOf("src/main/java")
+    classDirectories.setFrom(files(javaDirectories, kotlinDirectories))
+    additionalClassDirs.setFrom(files(coverageSrcDirectories))
+    sourceDirectories.setFrom(files(coverageSrcDirectories))
+    executionData.setFrom(
+        files("${project.buildDir}/jacoco/testDebugUnitTest.exec")
+    )
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ lifecycleViewmodelKtx = "2.7.0"
 navigationFragmentKtx = "2.7.7"
 navigationUiKtx = "2.7.7"
 
+# buildSrc dependencies
+jetbrainsKotlinGradlePlugin = "1.9.23"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -26,7 +29,13 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 
+# buildSrc dependencies
+android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+jetbrains-kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "jetbrainsKotlinGradlePlugin" }
+
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 
+# custom precompiled script plugins from buildSrc
+jacocoReports = { id = "jacoco-reports", version = "undefined" }


### PR DESCRIPTION
### What has been done
- Added basic GitHub Actions CI configuration
- Configured JaCoCo test coverage. 
Two ways of applying/configuring JaCoCo when using Kotlin DSL - via binary plugins and via pre-compiled script plugins. I went with pre-compiled script plugins as it allows to preserve the plugin configuration without a full rewrite to Kotlin.
Guide https://medium.com/@kurtlemond/migrating-jacoco-reports-gradle-tasks-to-kotlin-dsl-7b566d89ea92.

Use https://github.com/vgaidarji/ci-matters/blob/master/.github/workflows/main.yaml in future to add more steps to CI/CD workflow.

### How to test
- Push new changes and verify CI is passing in Actions tab